### PR TITLE
calloc: bzero allocation

### DIFF
--- a/malloc.c
+++ b/malloc.c
@@ -47,6 +47,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <unistd.h>
 #include <stdarg.h>
 #include <fcntl.h>
@@ -1916,5 +1917,7 @@ realloc(void *ptr, size_t size)
 
 void *calloc(size_t n, size_t size)
 {
-  return malloc(n * size);
+  void *ptr = malloc(n * size);
+  bzero(ptr, n * size);
+  return ptr;
 }


### PR DESCRIPTION
Some user code in halvm-ghc expected zeroed memory from calloc, and received a dirty allocation.
Adding bzero fixed it, so either this is the problem or halvm-ghc has a buffer overrun somewhere important.
I can't see any magic in the malloc implementation that would imply zeroed memory?