### PR TITLE
Patches to minlibc to support HaLVM on GHC-8.0.1

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -37,4 +37,7 @@ int       unsetenv(const char *name);
 
 int       abs(int j);
 
+int rand (void);
+void srand (unsigned);
+
 #endif

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -16,6 +16,7 @@ typedef unsigned long int size_t;
 double    atof(const char *nptr);
 int       atoi(const char *nptr);
 long int  strtol(const char *nptr, char **endptr, int base);
+unsigned long long strtoull (const char *__restrict, char **__restrict, int);
 
 char     *getenv(const char *name);
 void      abort(void) __attribute__((noreturn));

--- a/rand.c
+++ b/rand.c
@@ -1,0 +1,19 @@
+// This file is from the musl project:
+//   http://musl-libc.org
+// License: MIT (Please refer to the original project for details)
+
+#include <stdlib.h>
+#include <stdint.h>
+
+static uint64_t seed;
+
+void srand(unsigned s)
+{
+	seed = s-1;
+}
+
+int rand(void)
+{
+	seed = 6364136223846793005ULL*seed + 1;
+	return seed>>33;
+}

--- a/strtol.c
+++ b/strtol.c
@@ -136,3 +136,7 @@ long int strtol(const char *nptr, char **endptr, int base)
   return (acc);
 }
 
+unsigned long long strtoull (const char*__restrict nptr, char **__restrict endptr, int base) {
+    return (unsigned long long) strtol(nptr, endptr, base);
+    // HACK: Hope it won't break things severely before I change to musl
+}


### PR DESCRIPTION
The general efforts: https://github.com/GaloisInc/HaLVM/issues/82

Note that it is just some hacks for the temporary need, and `strtoull` might lead to unexpected bugs. Ideally, we should change to musl entirely in future.