### PR TITLE
Add USHRT_MAX

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -9,6 +9,7 @@
 
 #define SCHAR_MAX       127
 #define SHRT_MAX        32767
+#define USHRT_MAX       65535
 #define INT_MAX         2147483647
 #define UINT_MAX        4294967295U
 


### PR DESCRIPTION
cc @acw

`GMP 6.1.2` expects this, need this for `HaLVM`'s configured to use `gmp`