### PR TITLE
Optionally emulate /dev/urandom CRNG for transparent entropy on cryptonite

### DIFF
--- a/close.c
+++ b/close.c
@@ -8,9 +8,22 @@
 #include <stdio.h>
 #include <errno.h>
 
-int close(int fd __attribute__ ((unused)))
+#ifdef URANDOM
+#include <runtime_reqs.h>
+#define MUNUSED
+#else
+#define MUNUSED __attribute((unused))
+#endif /* URANDOM */
+
+int close(int fd MUNUSED)
 {
   printf("close\n");
+
+#ifdef URANDOM
+  if(fd == URANDOM_FD)
+    return urandom_close();
+#endif
+
   errno = EBADF;
   return (-1);
 }

--- a/fstat.c
+++ b/fstat.c
@@ -7,9 +7,21 @@
 #include <sys/stat.h>
 #include <errno.h>
 
-int fstat(int fd __attribute__((unused)),
-          struct stat *buf __attribute__((unused)))
+#ifdef URANDOM
+#include <runtime_reqs.h>
+#define MUNUSED
+#else
+#define MUNUSED __attribute((unused))
+#endif /* URANDOM */
+
+int fstat(int fd           MUNUSED,
+          struct stat *buf MUNUSED)
 {
+#ifdef URANDOM
+  if(fd == URANDOM_FD)
+    return urandom_stat(buf, 1);
+#endif
+
   errno = EBADF;
   return -1;
 }

--- a/include/runtime_reqs.h
+++ b/include/runtime_reqs.h
@@ -9,8 +9,10 @@
 
 #include <sys/types.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <time.h>
 
 void    runtime_write(size_t len, char *buffer);
@@ -24,6 +26,14 @@ int     runtime_pagesize(void);
 time_t  runtime_time(void);
 int     runtime_gettimeofday(struct timeval *);
 int     runtime_rusage(int who, struct rusage *);
+
+#ifdef URANDOM
+#define URANDOM_FD 9001
+int     urandom_open(void);
+int     urandom_stat(struct stat *buf, int check_consumers);
+ssize_t urandom_read(uint8_t *buf, size_t len);
+int     urandom_close(void);
+#endif
 
 #ifdef PROFILING
 FILE   *profile_fopen(const char *fname, const char *mode);

--- a/lstat.c
+++ b/lstat.c
@@ -7,9 +7,21 @@
 #include <sys/stat.h>
 #include <errno.h>
 
-int lstat(const char *path __attribute__((unused)),
-          struct stat *buf __attribute__((unused)))
+#ifdef URANDOM
+#include <runtime_reqs.h>
+#include <string.h>
+#define MUNUSED
+#else
+#define MUNUSED __attribute((unused))
+#endif /* URANDOM */
+
+int lstat(const char *path MUNUSED,
+          struct stat *buf MUNUSED)
 {
-  errno = ENOENT;
+#ifdef URANDOM
+  if(strncmp(path, "/dev/urandom", 13) == 0)
+    return urandom_stat(buf, 0);
+#endif
+
   return -1;
 }

--- a/open.c
+++ b/open.c
@@ -8,11 +8,25 @@
 #include <stdio.h>
 #include <errno.h>
 
-int open(const char *pathname __attribute__((unused)),
-         int flags __attribute__((unused)),
+#ifdef URANDOM
+#include <runtime_reqs.h>
+#include <string.h>
+#define MUNUSED
+#else
+#define MUNUSED __attribute((unused))
+#endif /* URANDOM */
+
+int open(const char *pathname MUNUSED,
+         int flags            MUNUSED,
          ...)
 {
   printf("open\n");
+
+#ifdef URANDOM
+  if(strncmp(pathname, "/dev/urandom", 13) == 0 && (flags & ~O_NONBLOCK) == O_RDONLY)
+    return urandom_open();
+#endif
+
   errno = EACCES;
   return -1;
 }

--- a/read.c
+++ b/read.c
@@ -8,11 +8,24 @@
 #include <stdio.h>
 #include <errno.h>
 
-ssize_t read(int fildes __attribute__((unused)),
-             void *buf __attribute__((unused)),
-             size_t nbyte __attribute__((unused)))
+#ifdef URANDOM
+#include <runtime_reqs.h>
+#define MUNUSED
+#else
+#define MUNUSED __attribute((unused))
+#endif /* URANDOM */
+
+ssize_t read(int fildes   MUNUSED,
+             void *buf    MUNUSED,
+             size_t nbyte MUNUSED)
 {
   printf("read\n");
+
+#ifdef URANDOM
+  if(fildes == URANDOM_FD)
+    return urandom_read(buf, nbyte);
+#endif
+
   errno = EBADF;
   return -1;
 }

--- a/stat.c
+++ b/stat.c
@@ -7,9 +7,22 @@
 #include <errno.h>
 #include <sys/stat.h>
 
-int stat(const char *path __attribute__((unused)),
-         struct stat *buf __attribute__((unused)))
+#ifdef URANDOM
+#include <runtime_reqs.h>
+#include <string.h>
+#define MUNUSED
+#else
+#define MUNUSED __attribute((unused))
+#endif /* URANDOM */
+
+int stat(const char *path MUNUSED,
+         struct stat *buf MUNUSED)
 {
-    errno = EACCES;
-    return -1;
+#ifdef URANDOM
+  if(strncmp(path, "/dev/urandom", 13) == 0)
+    return urandom_stat(buf, 0);
+#endif
+
+  errno = EACCES;
+  return -1;
 }


### PR DESCRIPTION
For some applications (e.g., using libraries that rely on `cryptonite`'s `getRandomBytes` run in `IO` on architectures without the RDRAND instruction), it would be useful to have a source of entropy on HaLVM with a transparent interface via reading `/dev/urandom`. This branch accomplishes that.

If `--enable-urandom` is passed to `configure`, the functions in `System.IO`, `Data.ByteString`, etc., that could be used to read `/dev/urandom` succeed. The bytes returned are the output of a port of the ChaCha20 CRNG used in Linux 4.14 for `/dev/urandom`. The CRNG is seeded with the low-order bits of multiple invocations of `rdtsc`, which is what Linux does on `x86_64` when `RDRAND` isn't available.

If nothing or `--disable-urandom` is passed to `configure`, all associated code is removed by the prerocessor.